### PR TITLE
fix centos7 buildout error "ImportError: No module named six.moves"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -217,6 +217,18 @@
   register: extra_dir_copy_result
   when: instance_config.plone_buildout_extra_dir
 
+# Plone 5.0+; avoid bootstrap.py CentOS7
+- name: pip install requirements missing on CentOS7
+  become_user: "{{ instance_config.plone_buildout_user }}"
+  command: "{{ plone_instance_home }}/bin/pip install {{ item }}"
+  args:
+    creates: "{{ plone_instance_home }}/bin/buildout"
+  when: instance_config.plone_version >= '5.0' and ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7'
+  with_items: 
+    - appdirs
+    - packaging
+    - six
+
 # Plone 5.0+; avoid bootstrap.py
 - name: pip install zc.buildout
   command: "{{ plone_instance_home }}/bin/pip install zc.buildout=={{ instance_config.plone_zc_buildout_version }}"


### PR DESCRIPTION
added new play in  tasks/main.yml "# Plone 5.0+; avoid bootstrap.py CentOS7" to install virtualenv requirements for successful buildout issue.